### PR TITLE
Remove redundant version tag from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jquery-slugify",
-  "version": "1.2.3",
   "homepage": "https://github.com/madflow/jquery-slugify",
   "authors": [
     "madflow"


### PR DESCRIPTION
Bower now uses git version tags instead (http://semver.org/).